### PR TITLE
Fix broken setCellImage

### DIFF
--- a/lpod/table.py
+++ b/lpod/table.py
@@ -3055,7 +3055,7 @@ class odf_table(odf_element):
             cell.delete(child)
         # Now it all depends on the document type
         if type == 'spreadsheet':
-            image_frame.set_frame_anchor_type(None)
+            image_frame.set_anchor_type(None)
             # The frame needs end coordinates
             width, height = image_frame.get_size()
             image_frame.set_attribute('table:end-x', width)


### PR DESCRIPTION
Replace obviously discontinued set_frame_anchor_type by set_anchor_type

See in frame.py l. 342 : 

>   #set_frame_anchor_type = obsolete('set_frame_anchor_type', set_anchor_type)
