### PR TITLE
Handle the "number" styles family.

### DIFF
--- a/lpod/styles.py
+++ b/lpod/styles.py
@@ -35,6 +35,7 @@ context_mapping = {
         'paragraph': ('//office:styles', '//office:automatic-styles'),
         'text': ('//office:styles',),
         'graphic': ('//office:styles',),
+        'number': ('//office:styles',),
         'page-layout': ('//office:automatic-styles',),
         'master-page': ('//office:master-styles',),
         'font-face': ('//office:font-face-decls',),


### PR DESCRIPTION
Adds support for the "number" family when applying styles.

I needed this when merging two documents together (one containing some content and the other one containing the general layout and styles). Prior to this change, a traceback was generated with the error message "unknown family 'number'".

Not really sure if this is the correct way to do it (I'm not really tech-savvy when it comes to OpenDocument files or lpod), but this seems to fix the issue for me.